### PR TITLE
Use art as primary key and add zoo detail fetcher

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+beautifulsoup4
+requests
+pytest

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+set -e
+python3 -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+pip install -r requirements.txt


### PR DESCRIPTION
## Summary
- split zoo detail retrieval into `fetch_zoo_popup_soup`, `parse_zoo_popup`, and a thin `fetch_zoo_details` wrapper returning a dict
- harden parsing via a `ZooInfo` dataclass, &nbsp; cleanup, and graceful handling of missing website
- enable foreign keys and enrichment columns in `animal`, add index on `(country, city, name)`
- use a shared `requests.Session` with retries and UA for robustness
- add tests for missing website, spacing/nbsp quirks, and city-only zoo titles

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c81e625448328b43c3e6cb8991514