### PR TITLE
Use zoo map API and IDs for zoo records

### DIFF
--- a/tests/test_get_or_create_zoo.py
+++ b/tests/test_get_or_create_zoo.py
@@ -1,0 +1,74 @@
+import sqlite3
+from unittest.mock import patch
+from bs4 import BeautifulSoup
+
+from zootier_scraper_sqlite import (
+    ensure_db_schema,
+    get_or_create_zoo,
+    ZooLocation,
+)
+
+SAMPLE_ZOO_INFO = (
+    '<div class="datum">Lyon (Zoo)</div>'
+    '<div class="inhalt">Land: Frankreich<br>Website: '
+    '<a target="_blank" href="http://fr.zoo-infos.org/zoos-de/9998.html">'
+    'http://fr.zoo-infos.org/zoos-de/9998.html</a><br></div>'
+)
+
+SAMPLE_ZOO_INFO_NO_WEBSITE = (
+    '<div class="datum">Lyon (Zoo)</div>'
+    '<div class="inhalt">Land: Frankreich<br></div>'
+)
+
+
+def test_get_or_create_zoo_upserts_coordinates():
+    conn = sqlite3.connect(":memory:")
+    ensure_db_schema(conn)
+    soup = BeautifulSoup(SAMPLE_ZOO_INFO, "html.parser")
+
+    with patch("zootier_scraper_sqlite.fetch_zoo_popup_soup", return_value=soup):
+        with conn:
+            zoo_id = get_or_create_zoo(conn, ZooLocation(123, 1.23, 4.56))
+    assert zoo_id == 123
+
+    cur = conn.cursor()
+    cur.execute("SELECT latitude, longitude FROM zoo WHERE zoo_id=123")
+    assert cur.fetchone() == (1.23, 4.56)
+
+    # Second call updates coordinates
+    with patch("zootier_scraper_sqlite.fetch_zoo_popup_soup", return_value=soup):
+        with conn:
+            zoo_id2 = get_or_create_zoo(conn, ZooLocation(123, 7.89, 0.12))
+    assert zoo_id2 == 123
+    cur.execute("SELECT latitude, longitude FROM zoo WHERE zoo_id=123")
+    assert cur.fetchone() == (7.89, 0.12)
+    conn.close()
+
+
+def test_get_or_create_zoo_fills_missing_fields_and_refreshes():
+    conn = sqlite3.connect(":memory:")
+    ensure_db_schema(conn)
+
+    # Insert initial row without website
+    soup_no = BeautifulSoup(SAMPLE_ZOO_INFO_NO_WEBSITE, "html.parser")
+    with patch("zootier_scraper_sqlite.fetch_zoo_popup_soup", return_value=soup_no):
+        with conn:
+            get_or_create_zoo(conn, ZooLocation(321, 1.0, 2.0))
+
+    cur = conn.cursor()
+    cur.execute("SELECT website, latitude, longitude FROM zoo WHERE zoo_id=321")
+    assert cur.fetchone() == (None, 1.0, 2.0)
+
+    # Second call provides website and new coordinates
+    soup = BeautifulSoup(SAMPLE_ZOO_INFO, "html.parser")
+    with patch("zootier_scraper_sqlite.fetch_zoo_popup_soup", return_value=soup):
+        with conn:
+            get_or_create_zoo(conn, ZooLocation(321, 3.0, 4.0))
+
+    cur.execute("SELECT website, latitude, longitude FROM zoo WHERE zoo_id=321")
+    assert cur.fetchone() == (
+        "http://fr.zoo-infos.org/zoos-de/9998.html",
+        3.0,
+        4.0,
+    )
+    conn.close()

--- a/zootier_scraper_sqlite.py
+++ b/zootier_scraper_sqlite.py
@@ -53,13 +53,13 @@ def get_links(params, pattern, description):
     return found
 
 
-def parse_species(species_url):
+def parse_species(species_url: str, animal_id: int):
     print(f"[>] Fetching species page: {species_url}")
     r = SESSION.get(species_url)
     r.raise_for_status()
     time.sleep(SLEEP_SECONDS)
     soup = BeautifulSoup(r.text, "html.parser")
-    
+
     # Page name (like async version), stripped of any parenthesized suffix
     page_td = soup.find('td', class_='pageName')
     raw_name = page_td.get_text(" ", strip=True) if page_td else ''
@@ -83,42 +83,13 @@ def parse_species(species_url):
             latin = i.text.strip()
             break
 
-    # Zoos with continent, country, city & zoo name
-    zoos = []
-    for tab in soup.find_all("table", id="tab"):
-        cont_td = tab.find("td", {"align": "center", "id": "tagline"})
-        if not cont_td or not (cont_a := cont_td.find("a")):
-            continue
-        continent = cont_a.text.strip()
+    # Fetch zoo locations via map endpoint
+    map_soup = fetch_zoo_map_soup(animal_id)
+    zoos = parse_zoo_map(map_soup)
 
-        for row in tab.find_all("tr", class_=re.compile(r"^kontinent_\d+$")):
-            country_a = row.find("a", onclick=re.compile(r"toggleTagVisibility"))
-            if not country_a:
-                continue
-            country = re.sub(r"\s*\([^)]*\):?", "", country_a.text.strip())
-
-            div = row.find("div", id=re.compile(r"_zoos$"))
-            if not div:
-                continue
-
-            for zoo_a in div.find_all("a", onclick=re.compile(r"overlib")):
-                raw = zoo_a.text.strip()
-                m = re.match(r"^\s*([^(]+?)\s*\((.*)\)\s*$", raw)
-                if m:
-                    city = m.group(1).strip()
-                    name = m.group(2).strip()
-                    name = re.sub(r"\s*\(ehemals[^)]*\)", "", name).strip()
-                else:
-                    city = ''
-                    name = raw
-
-                zoos.append({
-                    "continent": continent,
-                    "country": country,
-                    "city": city,
-                    "name": name
-                })
-    print(f"    → Latin: {latin}, Zoos found: {len(zoos)}, Page: {page_name}, Desc: {len(desc)} fields")
+    print(
+        f"    → Latin: {latin}, Zoos found: {len(zoos)}, Page: {page_name}, Desc: {len(desc)} fields"
+    )
     return latin, zoos, page_name, desc
 
 
@@ -234,12 +205,14 @@ def ensure_db_schema(conn):
     c.execute(
         """
         CREATE TABLE IF NOT EXISTS zoo (
-            zoo_id      INTEGER PRIMARY KEY AUTOINCREMENT,
+            zoo_id      INTEGER PRIMARY KEY,
             continent   TEXT,
             country     TEXT,
             city        TEXT,
             name        TEXT,
-            UNIQUE(continent, country, city, name)
+            latitude    REAL,
+            longitude   REAL,
+            website     TEXT
         )
         """
     )
@@ -269,7 +242,6 @@ def update_animal_enrichment(conn, art, page_name, desc_dict):
         "UPDATE animal SET zootierliste_description = ?, zootierliste_name = ? WHERE art = ?",
         (desc_json, page_name, art)
     )
-    conn.commit()
 
 def get_or_create_animal(conn, klasse, ordnung, familie, art, latin_name):
     c = conn.cursor()
@@ -277,22 +249,45 @@ def get_or_create_animal(conn, klasse, ordnung, familie, art, latin_name):
         "INSERT OR IGNORE INTO animal (art, klasse, ordnung, familie, latin_name) VALUES (?, ?, ?, ?, ?)",
         (art, klasse, ordnung, familie, latin_name)
     )
-    conn.commit()
     return art
 
 
-def get_or_create_zoo(conn, continent, country, city, name):
-    c = conn.cursor()
-    c.execute(
-        "INSERT OR IGNORE INTO zoo (continent, country, city, name) VALUES (?, ?, ?, ?)",
-        (continent, country, city, name)
+def get_or_create_zoo(conn, location: ZooLocation) -> int:
+    """Insert or update a zoo using a single UPSERT."""
+    assert isinstance(location.zoo_id, int)
+    assert isinstance(location.latitude, float)
+    assert isinstance(location.longitude, float)
+
+    try:
+        info = parse_zoo_popup(fetch_zoo_popup_soup(location.zoo_id))
+    except Exception:
+        info = ZooInfo(country=None, website=None, city=None, name=None)
+
+    conn.execute(
+        (
+            """
+            INSERT INTO zoo (zoo_id, continent, country, city, name, latitude, longitude, website)
+            VALUES (?, NULL, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(zoo_id) DO UPDATE SET
+                latitude  = excluded.latitude,
+                longitude = excluded.longitude,
+                country   = COALESCE(zoo.country,  excluded.country),
+                city      = COALESCE(zoo.city,     excluded.city),
+                name      = COALESCE(zoo.name,     excluded.name),
+                website   = COALESCE(zoo.website,  excluded.website)
+            """
+        ),
+        (
+            location.zoo_id,
+            info.country,
+            info.city,
+            info.name,
+            location.latitude,
+            location.longitude,
+            info.website,
+        ),
     )
-    conn.commit()
-    c.execute(
-        "SELECT zoo_id FROM zoo WHERE continent=? AND country=? AND city=? AND name=?",
-        (continent, country, city, name)
-    )
-    return c.fetchone()[0]
+    return location.zoo_id
 
 
 def create_zoo_animal(conn, zoo_id, art):
@@ -301,7 +296,6 @@ def create_zoo_animal(conn, zoo_id, art):
         "INSERT OR IGNORE INTO zoo_animal (zoo_id, art) VALUES (?, ?)",
         (zoo_id, art)
     )
-    conn.commit()
 
 
 
@@ -347,24 +341,18 @@ def main():
                         continue
 
                     try:
-                        latin, zoos, page_name, desc = parse_species(sp_url)
+                        latin, zoos, page_name, desc = parse_species(sp_url, int(art))
                         if latin is None:
                             print(f"    ! Skipping species art={art} ({sp_url}) – missing Latin name.")
                             continue
-                        art_key = get_or_create_animal(
-                            conn, klasse, ordnung, familie, art, latin
-                        )
-                        # store enrichment (page name + description) for the animal
-                        update_animal_enrichment(conn, art_key, page_name, desc)
-                        for z in zoos:
-                            zoo_id = get_or_create_zoo(
-                                conn,
-                                z["continent"],
-                                z["country"],
-                                z["city"],
-                                z["name"]
+                        with conn:
+                            art_key = get_or_create_animal(
+                                conn, klasse, ordnung, familie, art, latin
                             )
-                            create_zoo_animal(conn, zoo_id, art_key)
+                            update_animal_enrichment(conn, art_key, page_name, desc)
+                            for z in zoos:
+                                zoo_id = get_or_create_zoo(conn, z)
+                                create_zoo_animal(conn, zoo_id, art_key)
                     except Exception as e:
                         print(f"[!] Error processing species art={art}: {e}")
 


### PR DESCRIPTION
## Summary
- Fetch zoo locations for species via map endpoint
- Store zoos keyed by remote zoo_id with latitude/longitude and popup details
- Upsert zoo records with COALESCE to fill missing info and refresh coordinates
- Batch per-species DB operations in transactions
- Add tests covering coordinate refresh and website updates

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689c90b83184832898f14535147d4c7c