### PR TITLE
Add script to refetch zoo information

### DIFF
--- a/refetch_zoo.py
+++ b/refetch_zoo.py
@@ -1,0 +1,81 @@
+#!/usr/bin/env python3
+"""Refetch information for a zoo and store it in the SQLite database."""
+import argparse
+import sqlite3
+import time
+from bs4 import BeautifulSoup
+import requests
+
+from zootier_scraper_sqlite import (
+    DB_FILE,
+    MAP_ZOOS_URL,
+    SLEEP_SECONDS,
+    ensure_db_schema,
+    parse_zoo_popup,
+    fetch_zoo_popup_soup,
+    parse_zoo_map,
+    SESSION,
+    ZooLocation,
+    with_retry,
+)
+
+
+def fetch_zoo_location(zoo_id: int, session: requests.Session | None = None) -> ZooLocation:
+    """Fetch the latitude/longitude for a single zoo id."""
+    sess = session or SESSION
+    r = sess.get(MAP_ZOOS_URL, params={"showzoo": str(zoo_id)}, timeout=(5, 20))
+    r.raise_for_status()
+    time.sleep(SLEEP_SECONDS)
+    soup = BeautifulSoup(r.text, "html.parser")
+    locations = parse_zoo_map(soup)
+    for loc in locations:
+        if loc.zoo_id == zoo_id:
+            return loc
+    raise ValueError(f"Location for zoo {zoo_id} not found")
+
+
+def refetch_zoo(zoo_id: int, db_path: str = DB_FILE) -> None:
+    """Refetch info for the given zoo id and update the database."""
+    conn = sqlite3.connect(db_path, timeout=30)
+    ensure_db_schema(conn)
+    location = fetch_zoo_location(zoo_id)
+    info = parse_zoo_popup(fetch_zoo_popup_soup(zoo_id))
+    cur = conn.cursor()
+    with conn:
+        with_retry(
+            cur.execute,
+            """
+            INSERT INTO zoo (zoo_id, continent, country, city, name, latitude, longitude, website)
+            VALUES (?, NULL, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(zoo_id) DO UPDATE SET
+                country=excluded.country,
+                city=excluded.city,
+                name=excluded.name,
+                latitude=excluded.latitude,
+                longitude=excluded.longitude,
+                website=excluded.website
+            """,
+            (
+                zoo_id,
+                info.country,
+                info.city,
+                info.name,
+                location.latitude,
+                location.longitude,
+                info.website,
+            ),
+        )
+    conn.close()
+    return None
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Refetch info for a zoo and store in the DB")
+    parser.add_argument("zoo_id", type=int, help="Numeric zoo identifier")
+    parser.add_argument("--db", default=DB_FILE, help="Path to SQLite database file")
+    args = parser.parse_args()
+    refetch_zoo(args.zoo_id, args.db)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_refetch_zoo.py
+++ b/tests/test_refetch_zoo.py
@@ -1,0 +1,43 @@
+import sqlite3
+from unittest.mock import Mock
+
+from bs4 import BeautifulSoup
+
+import refetch_zoo
+from refetch_zoo import fetch_zoo_location
+from zootier_scraper_sqlite import ZooLocation
+
+
+def test_fetch_zoo_location_makes_request(monkeypatch):
+    text = (
+        "point\ttitle\tdescription\ticon\n"
+        "51.1285,5.14594\t10000950\t\timages/marker.png\n"
+    )
+    mock_resp = Mock(status_code=200, text=text)
+    get_mock = Mock(return_value=mock_resp)
+    monkeypatch.setattr("refetch_zoo.SESSION.get", get_mock)
+    monkeypatch.setattr("refetch_zoo.time.sleep", lambda _: None)
+    loc = fetch_zoo_location(10000950)
+    get_mock.assert_called_once_with(
+        "https://www.zootierliste.de/map_zoos.php",
+        params={"showzoo": "10000950"},
+        timeout=(5, 20),
+    )
+    assert loc == ZooLocation(10000950, 51.1285, 5.14594)
+
+
+def test_refetch_zoo_updates_database(tmp_path, monkeypatch):
+    db_path = tmp_path / "test.db"
+    location = ZooLocation(555, 1.23, 4.56)
+    monkeypatch.setattr(refetch_zoo, "fetch_zoo_location", lambda _z: location)
+    sample = '<div class="datum">City (Name)</div><div class="inhalt">Land: Country<br></div>'
+    soup = BeautifulSoup(sample, "html.parser")
+    monkeypatch.setattr(refetch_zoo, "fetch_zoo_popup_soup", lambda _z: soup)
+    refetch_zoo.refetch_zoo(555, str(db_path))
+    conn = sqlite3.connect(db_path)
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT zoo_id, country, city, name, latitude, longitude FROM zoo WHERE zoo_id=555"
+    )
+    assert cur.fetchone() == (555, "Country", "City", "Name", 1.23, 4.56)
+    conn.close()


### PR DESCRIPTION
## Summary
- add `refetch_zoo.py` script to update a zoo's coordinates and details in the SQLite database
- include helper to retrieve a single zoo's map location
- test refetch workflow and map retrieval

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689dafaa77b08328bda21e39aced862a