### PR TITLE
Add script to detect suspicious zoo coordinates

### DIFF
--- a/check_zoo_coordinates.py
+++ b/check_zoo_coordinates.py
@@ -1,0 +1,130 @@
+#!/usr/bin/env python3
+"""Check zoo coordinates for invalid ranges and outliers.
+
+This script inspects the ``zoo`` table of the zootierliste database and
+reports entries with latitude/longitude values outside the valid geographic
+range or statistical outliers per country based on the interquartile range
+(IQR) rule.
+
+Usage:
+    python check_zoo_coordinates.py [DB_FILE]
+
+If ``DB_FILE`` is omitted, ``zootierliste.db`` in the current directory is
+used.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sqlite3
+from collections import defaultdict
+from dataclasses import dataclass
+from statistics import quantiles
+from typing import Dict, Iterable, List, Optional, Sequence
+
+DB_FILE = "zootierliste.db"
+
+
+@dataclass
+class ZooRecord:
+    """A single row from the ``zoo`` table."""
+
+    zoo_id: int
+    country: Optional[str]
+    latitude: Optional[float]
+    longitude: Optional[float]
+    name: Optional[str]
+
+
+@dataclass
+class Suspicious:
+    """A record flagged for some reason."""
+
+    record: ZooRecord
+    reasons: List[str]
+
+
+def fetch_rows(conn: sqlite3.Connection) -> List[ZooRecord]:
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT zoo_id, country, latitude, longitude, name FROM zoo"
+    )
+    rows = [ZooRecord(*r) for r in cur.fetchall()]
+    return rows
+
+
+def _compute_bounds(values: Sequence[float]) -> Optional[tuple[float, float]]:
+    if len(values) < 4:
+        return None
+    q1, _, q3 = quantiles(values, n=4, method="inclusive")
+    iqr = q3 - q1
+    lower = q1 - 1.5 * iqr
+    upper = q3 + 1.5 * iqr
+    return lower, upper
+
+
+def find_suspicious(rows: Iterable[ZooRecord]) -> Dict[int, Suspicious]:
+    flagged: Dict[int, Suspicious] = {}
+    groups: Dict[Optional[str], List[ZooRecord]] = defaultdict(list)
+
+    for r in rows:
+        reasons = []
+        if r.latitude is None or r.longitude is None:
+            reasons.append("missing")
+        else:
+            if not (-90 <= r.latitude <= 90):
+                reasons.append("latitude range")
+            if not (-180 <= r.longitude <= 180):
+                reasons.append("longitude range")
+        if reasons:
+            flagged[r.zoo_id] = Suspicious(r, reasons)
+        else:
+            groups[r.country].append(r)
+
+    for country, entries in groups.items():
+        lat_bounds = _compute_bounds([e.latitude for e in entries])
+        lon_bounds = _compute_bounds([e.longitude for e in entries])
+        for e in entries:
+            reasons = []
+            if lat_bounds:
+                lo, hi = lat_bounds
+                if not (lo <= e.latitude <= hi):
+                    reasons.append("latitude iqr")
+            if lon_bounds:
+                lo, hi = lon_bounds
+                if not (lo <= e.longitude <= hi):
+                    reasons.append("longitude iqr")
+            if reasons:
+                if e.zoo_id in flagged:
+                    flagged[e.zoo_id].reasons.extend(reasons)
+                else:
+                    flagged[e.zoo_id] = Suspicious(e, reasons)
+
+    return flagged
+
+
+def main(db_path: str) -> None:
+    conn = sqlite3.connect(db_path)
+    try:
+        rows = fetch_rows(conn)
+    finally:
+        conn.close()
+
+    flagged = find_suspicious(rows)
+    for s in flagged.values():
+        r = s.record
+        reason = ", ".join(sorted(set(s.reasons)))
+        print(
+            f"{r.zoo_id}\t{r.country}\t{r.name}\t{r.latitude}\t{r.longitude}\t{reason}"
+        )
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "db",
+        nargs="?",
+        default=DB_FILE,
+        help="Path to the SQLite database (default: zootierliste.db)",
+    )
+    main(parser.parse_args().db)

--- a/tests/test_check_zoo_coordinates.py
+++ b/tests/test_check_zoo_coordinates.py
@@ -1,0 +1,46 @@
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _prepare_db(path: Path) -> Path:
+    conn = sqlite3.connect(path)
+    conn.execute(
+        "CREATE TABLE zoo (zoo_id INTEGER PRIMARY KEY, country TEXT, latitude REAL, longitude REAL, name TEXT)"
+    )
+    data = [
+        (1, 'X', 10.0, 20.0, 'a'),
+        (2, 'X', 11.0, 21.0, 'b'),
+        (3, 'X', 12.0, 22.0, 'c'),
+        (4, 'X', 13.0, 23.0, 'd'),
+        (5, 'X', 50.0, 24.0, 'e'),  # latitude outlier
+        (6, 'Y', 95.0, 30.0, 'f'),  # invalid latitude
+        (7, 'Y', 10.0, 190.0, 'g'),  # invalid longitude
+        (8, 'Z', None, 40.0, 'h'),  # missing latitude
+        (9, 'W', 40.0, -10.0, 'i'),
+        (10, 'W', 40.0, -11.0, 'j'),
+        (11, 'W', 40.0, -12.0, 'k'),
+        (12, 'W', 40.0, -13.0, 'l'),
+        (13, 'W', 40.0, -60.0, 'm'),  # longitude outlier
+    ]
+    conn.executemany("INSERT INTO zoo VALUES (?,?,?,?,?)", data)
+    conn.commit()
+    conn.close()
+    return path
+
+
+def test_check_zoo_coordinates(tmp_path):
+    db_path = _prepare_db(tmp_path / 'test.db')
+    result = subprocess.run(
+        [sys.executable, str(Path(__file__).resolve().parent.parent / 'check_zoo_coordinates.py'), str(db_path)],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    out = result.stdout
+    assert '5' in out and 'latitude iqr' in out
+    assert '6' in out and 'latitude range' in out
+    assert '7' in out and 'longitude range' in out
+    assert '8' in out and 'missing' in out
+    assert '13' in out and 'longitude iqr' in out


### PR DESCRIPTION
## Summary
- Add `check_zoo_coordinates.py` to validate zoo latitude/longitude ranges and flag interquartile outliers per country
- Include test ensuring detection of invalid or outlying coordinates

## Testing
- `ruff check .`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689daf56a408832884861c14dd47ddc1