### PR TITLE
Normalize latin animal names

### DIFF
--- a/latin_name_parser.py
+++ b/latin_name_parser.py
@@ -1,0 +1,180 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import List, Optional, Tuple
+
+_LNUMBER_RE = re.compile(r"\bL\s*-?\s*(\d{1,3})\b", re.I)
+# Regex used only to quickly check whether parentheses exist.
+_SEGMENT_HINT_RE = re.compile(r"\(")
+
+
+@dataclass
+class ParsedLatinName:
+    normalized: Optional[str]
+    alternative_names: List[str]
+    qualifier: Optional[str]
+    qualifier_target: Optional[str]
+    locality: Optional[str]
+    trade_code: Optional[str]
+
+
+def _top_level_segments(text: str) -> List[str]:
+    """Extract top-level ``(...)`` segments from ``text`` supporting nesting."""
+
+    segs: List[str] = []
+    depth = 0
+    buf: List[str] = []
+    for ch in text:
+        if ch == "(":
+            if depth == 0:
+                buf = []
+            else:
+                buf.append(ch)
+            depth += 1
+        elif ch == ")":
+            depth -= 1
+            if depth == 0:
+                segs.append("".join(buf))
+            else:
+                buf.append(ch)
+        elif depth > 0:
+            buf.append(ch)
+    return segs
+
+
+def _canonicalize_name(
+    name: str,
+    genus_context: Optional[str],
+    species_context: Optional[str],
+) -> Tuple[Optional[str], Optional[str], Optional[str], Optional[str], Optional[str]]:
+    """Return canonical form of ``name`` and updated contexts."""
+
+    if not name:
+        return None, genus_context, species_context, None, None
+
+    name = name.replace("spec.", "sp.").strip()
+    name = re.sub(r'"[^\"]+"', "", name)
+    tokens = name.split()
+    if not tokens:
+        return None, genus_context, species_context, None, None
+
+    genus = tokens[0]
+    if genus.endswith(".") and len(genus) == 2 and genus_context and genus_context.startswith(genus[0]):
+        genus = genus_context
+    else:
+        genus_context = genus
+
+    qualifier = None
+    qualifier_target = None
+    species = None
+    subspecies: List[str] = []
+    i = 1
+    while i < len(tokens):
+        t = tokens[i]
+        if t in {"cf.", "aff."}:
+            if i + 1 < len(tokens):
+                next_tok = tokens[i + 1]
+                if species is None:
+                    species = next_tok
+                elif species == "sp.":
+                    pass
+                species_context = next_tok
+                qualifier = t[:-1]
+                qualifier_target = next_tok
+                i += 2
+                continue
+            i += 1
+            continue
+        elif t == "sp.":
+            if species is None:
+                species = "sp."
+            i += 1
+            continue
+        elif t.endswith(".") and len(t) == 2 and species_context and species_context.startswith(t[0]):
+            if species is None:
+                species = species_context
+            i += 1
+            continue
+        else:
+            if species is None:
+                species = t
+                species_context = species
+            else:
+                subspecies.append(t)
+        i += 1
+
+    parts = [p for p in [genus, species, *subspecies] if p]
+    return (
+        " ".join(parts).strip(),
+        genus_context,
+        species_context,
+        qualifier,
+        qualifier_target,
+    )
+
+
+def parse_latin_name(name: Optional[str]) -> ParsedLatinName:
+    """Parse a Latin name string and extract structured information."""
+
+    if not name:
+        return ParsedLatinName(None, [], None, None, None, None)
+
+    locality = None
+    trade_code = None
+    qualifier = None
+    qualifier_target = None
+    alternative: List[str] = []
+
+    segments = _top_level_segments(name) if _SEGMENT_HINT_RE.search(name) else []
+    core = name
+    for seg in segments:
+        core = core.replace(f"({seg})", " ")
+
+    quotes = re.findall(r'"([^\"]+)"', core)
+    if quotes:
+        locality = quotes[0]
+    core = re.sub(r'"[^\"]+"', '', core).strip()
+
+    m = _LNUMBER_RE.search(core)
+    if m:
+        trade_code = f"L{m.group(1)}"
+        core = _LNUMBER_RE.sub('', core).strip()
+
+    for raw_seg in segments:
+        content = raw_seg.strip()
+        if re.fullmatch(r"(cf|aff)\.", content):
+            qualifier = content[:-1]
+            continue
+        m = re.match(r"(?i)(syn\.|misid\.|inkl\.|incl\.)\s*:?\s*(.+)", content)
+        if m:
+            alternative.append(m.group(2).strip())
+            continue
+        m = _LNUMBER_RE.search(content)
+        if m:
+            if not trade_code:
+                trade_code = f"L{m.group(1)}"
+            rest = _LNUMBER_RE.sub('', content).strip()
+            if rest:
+                if re.search(r"\b(Rio|River|Lago|Lake|See)\b", rest, re.I):
+                    locality = locality or rest
+                else:
+                    alternative.append(rest)
+            continue
+        if content:
+            alternative.append(content)
+
+    normalized, genus_ctx, species_ctx, qual, qual_target = _canonicalize_name(core, None, None)
+    alt_results: List[str] = []
+    for alt in alternative:
+        canon, genus_ctx, species_ctx, _, _ = _canonicalize_name(alt, genus_ctx, species_ctx)
+        if canon and canon not in alt_results:
+            alt_results.append(canon)
+
+    if qualifier and not qualifier_target and species_ctx and species_ctx != "sp.":
+        qualifier_target = species_ctx
+    if qual and not qualifier:
+        qualifier = qual
+        qualifier_target = qualifier_target or qual_target
+
+    return ParsedLatinName(normalized, alt_results, qualifier, qualifier_target, locality, trade_code)

--- a/normalize_latin_names.py
+++ b/normalize_latin_names.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Utilities to normalize and enrich Latin animal names in the SQLite database.
+
+This script adds additional columns to the ``animal`` table based on the existing
+``latin_name`` column. It relies on :func:`latin_name_parser.parse_latin_name`
+to extract a canonical name, alternative spellings, qualifiers, locality labels
+and trade codes. The main entry point for reprocessing an existing database is
+:func:`update_animals` which can be executed as a script.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+from typing import Optional
+
+from zootier_scraper_sqlite import DB_FILE, ensure_db_schema
+from latin_name_parser import parse_latin_name
+
+def update_animals(conn: sqlite3.Connection) -> None:
+    """Populate normalized name columns for all rows in ``animal``."""
+
+    cur = conn.cursor()
+    for art, latin in cur.execute("SELECT art, latin_name FROM animal"):
+        parsed = parse_latin_name(latin)
+        cur.execute(
+            """
+            UPDATE animal SET
+                normalized_latin_name = ?,
+                alternative_latin_names = ?,
+                qualifier = ?,
+                qualifier_target = ?,
+                locality = ?,
+                trade_code = ?
+            WHERE art = ?
+            """,
+            (
+                parsed.normalized,
+                json.dumps(parsed.alternative_names, ensure_ascii=False),
+                parsed.qualifier,
+                parsed.qualifier_target,
+                parsed.locality,
+                parsed.trade_code,
+                art,
+            ),
+        )
+    conn.commit()
+
+def main(db_path: Optional[str] = None) -> None:
+    db_path = db_path or DB_FILE
+    conn = sqlite3.connect(db_path)
+    ensure_db_schema(conn)
+    update_animals(conn)
+    conn.close()
+
+if __name__ == "__main__":  # pragma: no cover - manual invocation
+    parser = argparse.ArgumentParser(
+        description="Normalize Latin names into extra columns",
+    )
+    parser.add_argument(
+        "--db",
+        help="Path to SQLite database (defaults to zootier_scraper_sqlite.DB_FILE)",
+    )
+    args = parser.parse_args()
+    main(args.db)

--- a/tests/test_latin_name_parser.py
+++ b/tests/test_latin_name_parser.py
@@ -1,0 +1,120 @@
+import sqlite3
+
+from latin_name_parser import parse_latin_name
+from normalize_latin_names import update_animals
+from zootier_scraper_sqlite import ensure_db_schema
+
+def test_simple_synonyms():
+    name = "Abantennarius coccineus(Syn.: Antennatus coccineus)(Syn.: Antennarius coccineus)"
+    parsed = parse_latin_name(name)
+    assert parsed.normalized == "Abantennarius coccineus"
+    assert parsed.alternative_names == [
+        "Antennatus coccineus",
+        "Antennarius coccineus",
+    ]
+
+
+def test_abbreviated_synonyms():
+    name = "Amazona farinosa farinosa(Syn.: A. f. chapmani)(Syn.: A. f. inornata)"
+    parsed = parse_latin_name(name)
+    assert parsed.normalized == "Amazona farinosa farinosa"
+    assert parsed.alternative_names == [
+        "Amazona farinosa chapmani",
+        "Amazona farinosa inornata",
+    ]
+
+
+def test_parenthetical_qualifier():
+    name = "Hymenochirus(cf.) boettgeri"
+    parsed = parse_latin_name(name)
+    assert parsed.normalized == "Hymenochirus boettgeri"
+    assert parsed.qualifier == "cf"
+    assert parsed.qualifier_target == "boettgeri"
+
+
+def test_trade_code_and_locality(tmp_path):
+    name = "Panaque cf. armbrusteri(L 27 Rio Araguaia)"
+    parsed = parse_latin_name(name)
+    assert parsed.normalized == "Panaque armbrusteri"
+    assert parsed.qualifier == "cf"
+    assert parsed.qualifier_target == "armbrusteri"
+    assert parsed.trade_code == "L27"
+    assert parsed.locality == "Rio Araguaia"
+
+    db = tmp_path / "db.sqlite"
+    conn = sqlite3.connect(db)
+    ensure_db_schema(conn)
+    c = conn.cursor()
+    c.execute(
+        "INSERT INTO animal (art, klasse, ordnung, familie, latin_name) VALUES (?,?,?,?,?)",
+        ("1", 1, 1, 1, name),
+    )
+    update_animals(conn)
+    row = c.execute(
+        "SELECT normalized_latin_name, alternative_latin_names, qualifier, qualifier_target, locality, trade_code FROM animal WHERE art=?",
+        ("1",),
+    ).fetchone()
+    assert row == (
+        "Panaque armbrusteri",
+        "[]",
+        "cf",
+        "armbrusteri",
+        "Rio Araguaia",
+        "L27",
+    )
+    conn.close()
+
+
+def test_chained_abbreviated_synonyms():
+    name = (
+        "Kinyongia multituberculata"
+        "(Syn.: Chamaeleon fischeri multituberculatus)"
+        "(Syn.: C. f. werneri)"
+    )
+    parsed = parse_latin_name(name)
+    assert parsed.normalized == "Kinyongia multituberculata"
+    assert parsed.alternative_names == [
+        "Chamaeleon fischeri multituberculatus",
+        "Chamaeleon fischeri werneri",
+    ]
+
+def test_aff_and_morph_label_in_quotes():
+    parsed = parse_latin_name('Oligosoma aff. infrapunctatum "Cobble"')
+    assert parsed.normalized == "Oligosoma infrapunctatum"
+    assert parsed.qualifier == "aff"
+    assert parsed.qualifier_target == "infrapunctatum"
+    assert parsed.locality == "Cobble"
+
+def test_sp_cf_placeholder():
+    parsed = parse_latin_name("Andriashevicottus sp. cf. megacephalus")
+    assert parsed.normalized == "Andriashevicottus sp."
+    assert parsed.qualifier == "cf"
+    assert parsed.qualifier_target == "megacephalus"
+
+def test_cf_simple():
+    parsed = parse_latin_name("Hyphessobrycon cf. pulchripinnis")
+    assert parsed.normalized == "Hyphessobrycon pulchripinnis"
+    assert parsed.qualifier == "cf"
+    assert parsed.qualifier_target == "pulchripinnis"
+
+def test_aff_simple():
+    parsed = parse_latin_name("Chitala aff. lopis")
+    assert parsed.normalized == "Chitala lopis"
+    assert parsed.qualifier == "aff"
+    assert parsed.qualifier_target == "lopis"
+
+def test_synonym_with_includes_and_abbrev():
+    parsed = parse_latin_name(
+        "Pterophyllum scalare(Syn.: Pterophyllum eimekei)(Syn.: P. dumerilii)(inkl. P. cf. scalare)"
+    )
+    assert parsed.normalized == "Pterophyllum scalare"
+    assert set(parsed.alternative_names) >= {
+        "Pterophyllum eimekei",
+        "Pterophyllum dumerilii",
+        "Pterophyllum scalare",
+    }
+
+def test_trade_code_and_locality_2():
+    parsed = parse_latin_name("Panaque cf. armbrusteri(L 27 Rio Tocantins)")
+    assert parsed.trade_code == "L27"
+    assert parsed.locality == "Rio Tocantins"

--- a/zootier_scraper_sqlite.py
+++ b/zootier_scraper_sqlite.py
@@ -274,7 +274,13 @@ def ensure_db_schema(conn):
             zootierliste_description TEXT,
             name_de     TEXT,
             name_en     TEXT,
-            zootierlexikon_link TEXT
+            zootierlexikon_link TEXT,
+            normalized_latin_name TEXT,
+            alternative_latin_names TEXT,
+            qualifier TEXT,
+            qualifier_target TEXT,
+            locality TEXT,
+            trade_code TEXT
         )
         """
     )
@@ -319,6 +325,18 @@ def ensure_db_schema(conn):
         c.execute("ALTER TABLE animal ADD COLUMN name_en TEXT")
     if "zootierlexikon_link" not in cols:
         c.execute("ALTER TABLE animal ADD COLUMN zootierlexikon_link TEXT")
+    if "normalized_latin_name" not in cols:
+        c.execute("ALTER TABLE animal ADD COLUMN normalized_latin_name TEXT")
+    if "alternative_latin_names" not in cols:
+        c.execute("ALTER TABLE animal ADD COLUMN alternative_latin_names TEXT")
+    if "qualifier" not in cols:
+        c.execute("ALTER TABLE animal ADD COLUMN qualifier TEXT")
+    if "qualifier_target" not in cols:
+        c.execute("ALTER TABLE animal ADD COLUMN qualifier_target TEXT")
+    if "locality" not in cols:
+        c.execute("ALTER TABLE animal ADD COLUMN locality TEXT")
+    if "trade_code" not in cols:
+        c.execute("ALTER TABLE animal ADD COLUMN trade_code TEXT")
 
     conn.commit()
 


### PR DESCRIPTION
## Summary
- extract Latin name parser into reusable module with nested-parenthesis handling
- allow normalization script to take a database path via `--db`
- broaden parser test coverage for qualifiers, includes and trade codes

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b47dc769f88328b6c0e32c23aea35a