### PR TITLE
Add inventory counts for animals and zoos

### DIFF
--- a/tests/test_update_counts.py
+++ b/tests/test_update_counts.py
@@ -1,0 +1,48 @@
+import os
+import sqlite3
+import sys
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+from zootier_scraper_sqlite import (
+    ensure_db_schema,
+    get_or_create_animal,
+    get_or_create_zoo,
+    create_zoo_animal,
+    update_counts,
+    ZooLocation,
+)
+
+
+def test_update_counts_populates_columns():
+    conn = sqlite3.connect(":memory:")
+    ensure_db_schema(conn)
+
+    with conn:
+        a1 = get_or_create_animal(conn, 1, 1, 1, "a1", "Latin1")
+        a2 = get_or_create_animal(conn, 1, 1, 1, "a2", "Latin2")
+        a3 = get_or_create_animal(conn, 1, 1, 1, "a3", "Latin3")
+        get_or_create_zoo(conn, ZooLocation(1, 0.0, 0.0))
+        get_or_create_zoo(conn, ZooLocation(2, 0.0, 0.0))
+        get_or_create_zoo(conn, ZooLocation(3, 0.0, 0.0))
+        create_zoo_animal(conn, 1, a1)
+        create_zoo_animal(conn, 2, a1)
+        create_zoo_animal(conn, 1, a2)
+
+    with conn:
+        update_counts(conn)
+
+    cur = conn.cursor()
+    cur.execute("SELECT zoo_count FROM animal WHERE art=?", (a1,))
+    assert cur.fetchone()[0] == 2
+    cur.execute("SELECT zoo_count FROM animal WHERE art=?", (a2,))
+    assert cur.fetchone()[0] == 1
+    cur.execute("SELECT zoo_count FROM animal WHERE art=?", (a3,))
+    assert cur.fetchone()[0] == 0
+    cur.execute("SELECT species_count FROM zoo WHERE zoo_id=1")
+    assert cur.fetchone()[0] == 2
+    cur.execute("SELECT species_count FROM zoo WHERE zoo_id=2")
+    assert cur.fetchone()[0] == 1
+    cur.execute("SELECT species_count FROM zoo WHERE zoo_id=3")
+    assert cur.fetchone()[0] == 0
+
+    conn.close()

--- a/update_counts.py
+++ b/update_counts.py
@@ -1,0 +1,24 @@
+#!/usr/bin/env python3
+"""Recalculate zoo and species counts in the SQLite database."""
+import argparse
+import sqlite3
+
+from zootier_scraper_sqlite import DB_FILE, ensure_db_schema, update_counts
+
+def main():
+    parser = argparse.ArgumentParser(description="Populate count columns for animals and zoos")
+    parser.add_argument("--db", default=DB_FILE, help="Path to SQLite database file")
+    args = parser.parse_args()
+
+    conn = sqlite3.connect(args.db)
+    ensure_db_schema(conn)
+    with conn:
+        update_counts(conn)
+    cur = conn.cursor()
+    animals = cur.execute("SELECT COUNT(*) FROM animal").fetchone()[0]
+    zoos = cur.execute("SELECT COUNT(*) FROM zoo").fetchone()[0]
+    conn.close()
+    print(f"Updated counts for {animals} animals and {zoos} zoos")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- refine `update_counts` to use DISTINCT queries with retry handling
- enforce non-null defaulted count columns and index `zoo_animal.art`
- expand tests for zero-count cases and enhance CLI output

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b48b86abc08328aa017628316cc513