### PR TITLE
Add utility to fetch German taxon names

### DIFF
--- a/fetch_taxon_names.py
+++ b/fetch_taxon_names.py
@@ -64,8 +64,8 @@ def extract_names(html: str) -> tuple[Dict[int, str], Dict[int, str], Dict[int, 
     """Extract German names for classes, orders and families from *html*."""
 
     soup = BeautifulSoup(html, "html.parser")
-    nav = soup.find(id="navigation")
-    anchors = nav.find_all("a", href=True) if nav else soup.find_all("a", href=True)
+    # Class links are not within #navigation; scan all anchors in the document.
+    anchors = soup.find_all("a", href=True)
 
     classes: Dict[int, str] = {}
     orders: Dict[int, str] = {}
@@ -73,9 +73,13 @@ def extract_names(html: str) -> tuple[Dict[int, str], Dict[int, str], Dict[int, 
 
     for a in anchors:
         href = a["href"]
-        if not href.startswith("?"):
+        # Accept both "?..." and "/?..." forms
+        if href.startswith("?"):
+            qs = parse_qs(href[1:])
+        elif href.startswith("/?"):
+            qs = parse_qs(href[2:])
+        else:
             continue
-        qs = parse_qs(href[1:])
         keys = set(qs)
         try:
             if keys == {"klasse"}:

--- a/tests/test_fetch_taxon_names.py
+++ b/tests/test_fetch_taxon_names.py
@@ -21,13 +21,16 @@ def test_ensure_name_tables_creates_tables():
 def test_extract_names_parses_html():
     html = """
     <div id="navigation">
-        <a href="?klasse=1">Säugetiere</a>
-        <a href="?klasse=2">Vögel</a>
         <a href="?klasse=1&ordnung=101">Kloakentiere</a>
         <a href="?klasse=1&ordnung=102">Beuteltiere</a>
         <a href="?klasse=1&ordnung=102&familie=10201">Testfamilie &amp; Co</a>
         <a href="?klasse=1&ordnung=102&familie=10202">Haustierrassen &nbsp;&amp; Zuchtformen</a>
         <a href="?klasse=1&ordnung=102&action=login">ignore</a>
+    </div>
+    <!-- Class links live outside #navigation on the real site -->
+    <div id="classes">
+        <a href="?klasse=1">Säugetiere</a>
+        <a href="/?klasse=2">Vögel</a>
     </div>
     """
     classes, orders, families = extract_names(html)


### PR DESCRIPTION
## Summary
- strengthen schema with foreign keys, unique constraints, and indexes for German taxon names
- parse HTML navigation links via query strings and normalize labels before storing
- add progress logging and optional `--only-missing`/`--limit` flags when fetching names

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c17301e3988328b39f3b721e8657b7