### PR TITLE
Add English taxon name fetching

### DIFF
--- a/infer_iucn_from_zootierliste.py
+++ b/infer_iucn_from_zootierliste.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
-import argparse, sqlite3, json, re, sys
+import argparse
+import json
+import re
+import sqlite3
 
 CODE_RE = re.compile(r"^\s*([A-Z]{2,3})(?:\b|-)")  # grabs LC, NT, VU, EN, CR, DD, NE, EW, EX, GEH-*
 

--- a/list_iucn_unique.py
+++ b/list_iucn_unique.py
@@ -1,5 +1,8 @@
 #!/usr/bin/env python3
-import argparse, sqlite3, json, re
+import argparse
+import json
+import re
+import sqlite3
 from collections import Counter, defaultdict
 
 CODE_RE = re.compile(r"^\s*([A-Z]{1,3})\b")
@@ -30,7 +33,8 @@ def main():
     for desc_text, iucn in cur.fetchall():
         # IUCN status (English)
         iucn_clean = (iucn or "").strip()
-        if iucn_clean == "": iucn_clean = None
+        if iucn_clean == "":
+            iucn_clean = None
         if iucn_clean is not None:
             iucn_counter[iucn_clean] += 1
 

--- a/tests/test_fetch_taxon_names.py
+++ b/tests/test_fetch_taxon_names.py
@@ -16,6 +16,13 @@ def test_ensure_name_tables_creates_tables():
         row[0] for row in cur.execute("SELECT name FROM sqlite_master WHERE type='table'")
     }
     assert {"klasse_name", "ordnung_name", "familie_name"} <= tables
+    for table, pk in [
+        ("klasse_name", "klasse"),
+        ("ordnung_name", "ordnung"),
+        ("familie_name", "familie"),
+    ]:
+        cols = {row[1] for row in cur.execute(f"PRAGMA table_info({table})")}
+        assert {pk, "name_de", "name_en"} <= cols
 
 
 def test_extract_names_parses_html():


### PR DESCRIPTION
## Summary
- store both German and English taxon names
- fetch English class/order/family names from zootierliste
- verify schema includes English columns

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c1848e08dc832897e3ba528ffe6160