### PR TITLE
Normalize country and continent names into lookup tables

### DIFF
--- a/normalize_geography.py
+++ b/normalize_geography.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""Normalize continent and country names into lookup tables.
+
+This script extracts unique continent and country names from a zoo table,
+creates ``continent_name`` and ``country_name`` tables with German and optional
+English name columns, and replaces the textual values in the ``zoo`` table with
+integer IDs referencing those lookup tables.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sqlite3
+from typing import Dict, Iterable, List, Tuple
+
+from copy_zoo_metadata import get_existing_columns
+
+
+def ensure_lookup_tables(conn: sqlite3.Connection) -> None:
+    """Ensure that the continent and country lookup tables exist."""
+    cur = conn.cursor()
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS continent_name (
+            id INTEGER PRIMARY KEY,
+            name_de TEXT NOT NULL UNIQUE,
+            name_en TEXT
+        )
+        """
+    )
+    cur.execute(
+        """
+        CREATE TABLE IF NOT EXISTS country_name (
+            id INTEGER PRIMARY KEY,
+            name_de TEXT NOT NULL UNIQUE,
+            name_en TEXT,
+            continent_id INTEGER REFERENCES continent_name(id)
+        )
+        """
+    )
+
+
+def collect_distinct_values(
+    conn: sqlite3.Connection, table: str, column: str
+) -> list[str]:
+    """Return sorted list of distinct non-empty values from ``table.column``."""
+    cur = conn.execute(
+        f'SELECT DISTINCT "{column}" FROM "{table}" '
+        f'WHERE "{column}" IS NOT NULL AND "{column}" <> "" ORDER BY "{column}"'
+    )
+    return [row[0] for row in cur.fetchall()]
+
+
+def populate_lookup(
+    conn: sqlite3.Connection, table: str, names: Iterable[str]
+) -> Dict[str, int]:
+    """Insert ``names`` into ``table`` and return a mapping name -> id."""
+    cur = conn.execute(f'SELECT id, name_de FROM "{table}"')
+    existing = {row[1]: row[0] for row in cur.fetchall()}
+    to_insert = [(name,) for name in names if name not in existing]
+    with conn:
+        conn.executemany(
+            f'INSERT OR IGNORE INTO "{table}" (name_de) VALUES (?)', to_insert
+        )
+    cur = conn.execute(f'SELECT id, name_de FROM "{table}"')
+    return {row[1]: row[0] for row in cur.fetchall()}
+
+
+def collect_country_continent_pairs(
+    conn: sqlite3.Connection, zoo_table: str
+) -> List[Tuple[str, str]]:
+    """Return unique ``(country, continent)`` pairs from ``zoo_table``."""
+    cur = conn.execute(
+        f'SELECT DISTINCT country, continent FROM "{zoo_table}" '
+        'WHERE country IS NOT NULL AND country <> "" '
+        'AND continent IS NOT NULL AND continent <> "" '
+        'ORDER BY country, continent'
+    )
+    return [(row[0], row[1]) for row in cur.fetchall()]
+
+
+def populate_countries(
+    conn: sqlite3.Connection,
+    pairs: Iterable[Tuple[str, str]],
+    continent_map: Dict[str, int],
+) -> Dict[str, int]:
+    """Insert countries with their continent IDs and return name -> id mapping."""
+    cur = conn.execute('SELECT id, name_de FROM country_name')
+    existing = {row[1]: row[0] for row in cur.fetchall()}
+    to_insert = [
+        (country, continent_map[continent])
+        for country, continent in pairs
+        if country not in existing
+    ]
+    with conn:
+        conn.executemany(
+            'INSERT OR IGNORE INTO country_name (name_de, continent_id) VALUES (?, ?)',
+            to_insert,
+        )
+        for country, continent in pairs:
+            continent_id = continent_map[continent]
+            conn.execute(
+                'UPDATE country_name SET continent_id = ? WHERE name_de = ?',
+                (continent_id, country),
+            )
+    cur = conn.execute('SELECT id, name_de FROM country_name')
+    return {row[1]: row[0] for row in cur.fetchall()}
+
+
+def replace_zoo_values(
+    conn: sqlite3.Connection,
+    zoo_table: str,
+    src_column: str,
+    dst_column: str,
+    mapping: Dict[str, int],
+) -> None:
+    """Fill ``dst_column`` with IDs based on matching ``src_column`` values."""
+    with conn:
+        conn.executemany(
+            f'UPDATE "{zoo_table}" SET "{dst_column}" = ? WHERE "{src_column}" = ?',
+            [(id_, name) for name, id_ in mapping.items()],
+        )
+
+
+def normalize_geography(
+    conn: sqlite3.Connection, zoo_table: str = "zoo"
+) -> None:
+    """Normalize continent and country names for ``zoo_table``."""
+    conn.execute("PRAGMA foreign_keys=ON")
+    cols = set(get_existing_columns(conn, zoo_table))
+    for required in ("continent", "country"):
+        if required not in cols:
+            raise SystemExit(f"Table '{zoo_table}' missing column '{required}'")
+
+    ensure_lookup_tables(conn)
+
+    continent_names = collect_distinct_values(conn, zoo_table, "continent")
+    continent_map = populate_lookup(conn, "continent_name", continent_names)
+
+    country_pairs = collect_country_continent_pairs(conn, zoo_table)
+    country_map = populate_countries(conn, country_pairs, continent_map)
+
+    # Add new integer columns and fill them
+    with conn:
+        conn.execute(
+            f'ALTER TABLE "{zoo_table}" ADD COLUMN continent_id INTEGER REFERENCES continent_name(id)'
+        )
+        conn.execute(
+            f'ALTER TABLE "{zoo_table}" ADD COLUMN country_id INTEGER REFERENCES country_name(id)'
+        )
+
+    replace_zoo_values(conn, zoo_table, "continent", "continent_id", continent_map)
+    replace_zoo_values(conn, zoo_table, "country", "country_id", country_map)
+
+    # Drop indexes that reference the soon-to-be-removed columns
+    cur = conn.execute(f'PRAGMA index_list("{zoo_table}")')
+    for row in cur.fetchall():
+        idx_name = row[1]
+        info = conn.execute(f'PRAGMA index_info("{idx_name}")').fetchall()
+        cols = [i[2] for i in info]
+        if any(col in {"continent", "country"} for col in cols):
+            with conn:
+                conn.execute(f'DROP INDEX "{idx_name}"')
+
+    # Drop old text columns and rename the new ID columns
+    with conn:
+        conn.execute(f'ALTER TABLE "{zoo_table}" DROP COLUMN continent')
+        conn.execute(f'ALTER TABLE "{zoo_table}" DROP COLUMN country')
+        conn.execute(f'ALTER TABLE "{zoo_table}" RENAME COLUMN continent_id TO continent')
+        conn.execute(f'ALTER TABLE "{zoo_table}" RENAME COLUMN country_id TO country')
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser(
+        description=(
+            "Move continent and country names to lookup tables and "
+            "store IDs in the zoo table"
+        )
+    )
+    ap.add_argument("db_path")
+    ap.add_argument("--zoo-table", default="zoo")
+    args = ap.parse_args()
+
+    conn = sqlite3.connect(args.db_path)
+    try:
+        normalize_geography(conn, args.zoo_table)
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_normalize_geography.py
+++ b/tests/test_normalize_geography.py
@@ -1,0 +1,105 @@
+import sqlite3
+
+from zootier_scraper_sqlite import ensure_db_schema
+from normalize_geography import normalize_geography
+
+
+def test_normalize_geography_creates_lookup_and_replaces_values():
+    conn = sqlite3.connect(":memory:")
+    ensure_db_schema(conn)
+    with conn:
+        conn.execute(
+            "INSERT INTO zoo(zoo_id, continent, country, city, name) "
+            "VALUES (1, 'Europa', 'Deutschland', 'Berlin', 'Zoo Berlin')"
+        )
+        conn.execute(
+            "INSERT INTO zoo(zoo_id, continent, country, city, name) "
+            "VALUES (2, 'Europa', 'Deutschland', 'Munich', 'Zoo Munich')"
+        )
+        conn.execute(
+            "INSERT INTO zoo(zoo_id, continent, country, city, name) "
+            "VALUES (3, 'Europa', 'Frankreich', 'Paris', 'Zoo Paris')"
+        )
+        conn.execute(
+            "INSERT INTO zoo(zoo_id, continent, country, city, name) "
+            "VALUES (4, 'Asien', 'Japan', 'Tokyo', 'Zoo Tokyo')"
+        )
+
+    normalize_geography(conn)
+
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT id, name_de, name_en FROM continent_name ORDER BY id"
+    )
+    assert cur.fetchall() == [(1, "Asien", None), (2, "Europa", None)]
+
+    cur.execute(
+        "SELECT id, name_de, name_en, continent_id FROM country_name ORDER BY id"
+    )
+    assert cur.fetchall() == [
+        (1, "Deutschland", None, 2),
+        (2, "Frankreich", None, 2),
+        (3, "Japan", None, 1),
+    ]
+
+    cur.execute("SELECT continent, country FROM zoo ORDER BY zoo_id")
+    assert cur.fetchall() == [(2, 1), (2, 1), (2, 2), (1, 3)]
+
+    # Foreign keys are enforced
+    assert conn.execute("PRAGMA foreign_keys").fetchone()[0] == 1
+
+    # Ensure name_en columns exist for future translations
+    cur.execute("PRAGMA table_info(continent_name)")
+    assert any(col[1] == "name_en" for col in cur.fetchall())
+    cur.execute("PRAGMA table_info(country_name)")
+    assert any(col[1] == "name_en" for col in cur.fetchall())
+
+    conn.close()
+
+
+def test_normalize_geography_drops_indexes_and_is_idempotent():
+    conn = sqlite3.connect(":memory:")
+    ensure_db_schema(conn)
+    # extra index that should survive
+    with conn:
+        conn.execute("CREATE INDEX idx_name ON zoo(name)")
+        conn.execute(
+            "INSERT INTO zoo(zoo_id, continent, country, city, name) "
+            "VALUES (1, 'Europa', 'Deutschland', 'Berlin', 'Zoo Berlin')"
+        )
+    normalize_geography(conn)
+
+    # zoo_name_idx references country and should be gone; idx_name remains
+    indexes = {
+        row[1]: row[2]
+        for row in conn.execute("PRAGMA index_list('zoo')").fetchall()
+    }
+    assert "idx_name" in indexes
+    assert "zoo_name_idx" not in indexes
+
+    # Run normalization again after recreating zoo table to ensure IDs stable
+    continents_first = conn.execute(
+        "SELECT id, name_de FROM continent_name ORDER BY id"
+    ).fetchall()
+    countries_first = conn.execute(
+        "SELECT id, name_de FROM country_name ORDER BY id"
+    ).fetchall()
+
+    with conn:
+        conn.execute("DROP TABLE zoo")
+    ensure_db_schema(conn)
+    with conn:
+        conn.execute(
+            "INSERT INTO zoo(zoo_id, continent, country, city, name) "
+            "VALUES (1, 'Europa', 'Deutschland', 'Berlin', 'Zoo Berlin')"
+        )
+    normalize_geography(conn)
+
+    assert continents_first == conn.execute(
+        "SELECT id, name_de FROM continent_name ORDER BY id"
+    ).fetchall()
+    assert countries_first == conn.execute(
+        "SELECT id, name_de FROM country_name ORDER BY id"
+    ).fetchall()
+
+    conn.close()


### PR DESCRIPTION
## Summary
- link `country_name` records to `continent_name` via foreign key and populate them from unique `(country, continent)` pairs
- preserve IDs across runs using upserts and enable SQLite foreign key enforcement
- drop any indexes referencing removed text columns generically

## Testing
- `ruff check .`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c3f9b5dbc88328ba34599693ab6556