### PR TITLE
Add Google Places zoo coordinate fetch script

### DIFF
--- a/google_places_fetch_zoo_coords.py
+++ b/google_places_fetch_zoo_coords.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 import argparse
 import sqlite3
 import sys
-from typing import Iterable, List, Optional, Sequence, Tuple
+from typing import Iterable, Optional, Sequence, Tuple
 
 from google_places_lookup import ApiError, lookup_coords
 from zootier_scraper_sqlite import DB_FILE
@@ -37,7 +37,7 @@ def ensure_google_columns(conn: sqlite3.Connection) -> None:
 
     cur = conn.execute("PRAGMA table_info(zoo)")
     columns = {row[1] for row in cur.fetchall()}
-    statements: List[str] = []
+    statements: list[str] = []
     if "latitude_google" not in columns:
         statements.append("ALTER TABLE zoo ADD COLUMN latitude_google REAL")
     if "longitude_google" not in columns:
@@ -87,7 +87,6 @@ def update_google_coordinates(
     *,
     dry_run: bool,
 ) -> int:
-    updates: List[Tuple[float, float, int]] = []
     success_count = 0
     for row in rows:
         query = build_query(row)
@@ -112,14 +111,11 @@ def update_google_coordinates(
         )
         success_count += 1
         if not dry_run:
-            updates.append((lat, lng, zoo_id))
-
-    if updates and not dry_run:
-        with conn:
-            conn.executemany(
+            conn.execute(
                 "UPDATE zoo SET latitude_google=?, longitude_google=? WHERE zoo_id=?",
-                updates,
+                (lat, lng, zoo_id),
             )
+            conn.commit()
     return success_count
 
 

--- a/google_places_fetch_zoo_coords.py
+++ b/google_places_fetch_zoo_coords.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Populate Google-based coordinates for zoos.
+
+This script augments the ``zoo`` table with additional latitude/longitude
+columns sourced from Google Maps. Existing ``latitude``/``longitude`` values
+remain untouched; the new values are stored in ``latitude_google`` and
+``longitude_google``.
+
+For every zoo where either of the Google columns is ``NULL`` the script runs a
+Places Text Search for "{name} {city}". If the database already contains
+coordinates, they are used as a soft bias (50 km radius) to guide the search.
+
+Usage example::
+
+    python google_places_fetch_zoo_coords.py --db path/to/zootierliste.db --limit 20
+
+Environment::
+
+    GOOGLE_MAPS_API_KEY must be set with access to the Places API.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sqlite3
+import sys
+from typing import Iterable, List, Optional, Sequence, Tuple
+
+from google_places_lookup import ApiError, lookup_coords
+from zootier_scraper_sqlite import DB_FILE
+
+GOOGLE_RADIUS_METERS = 50_000
+
+
+def ensure_google_columns(conn: sqlite3.Connection) -> None:
+    """Create latitude_google/longitude_google columns if they do not exist."""
+
+    cur = conn.execute("PRAGMA table_info(zoo)")
+    columns = {row[1] for row in cur.fetchall()}
+    statements: List[str] = []
+    if "latitude_google" not in columns:
+        statements.append("ALTER TABLE zoo ADD COLUMN latitude_google REAL")
+    if "longitude_google" not in columns:
+        statements.append("ALTER TABLE zoo ADD COLUMN longitude_google REAL")
+    for stmt in statements:
+        conn.execute(stmt)
+    if statements:
+        conn.commit()
+
+
+def load_target_rows(conn: sqlite3.Connection, limit: Optional[int]) -> Sequence[sqlite3.Row]:
+    """Fetch zoos requiring Google coordinates ordered by species_count desc."""
+
+    base_query = (
+        "SELECT zoo_id, name, city, latitude, longitude, species_count, "
+        "latitude_google, longitude_google "
+        "FROM zoo "
+        "WHERE latitude_google IS NULL OR longitude_google IS NULL "
+        "ORDER BY species_count DESC, zoo_id ASC"
+    )
+    if limit is not None:
+        base_query += " LIMIT ?"
+        rows = conn.execute(base_query, (limit,)).fetchall()
+    else:
+        rows = conn.execute(base_query).fetchall()
+    return rows
+
+
+def build_query(row: sqlite3.Row) -> Optional[str]:
+    parts = [part.strip() for part in (row["name"], row["city"]) if part]
+    if not parts:
+        return None
+    return " ".join(parts)
+
+
+def make_bias(row: sqlite3.Row) -> Optional[Tuple[float, float, int]]:
+    lat = row["latitude"]
+    lng = row["longitude"]
+    if lat is None or lng is None:
+        return None
+    return float(lat), float(lng), GOOGLE_RADIUS_METERS
+
+
+def update_google_coordinates(
+    conn: sqlite3.Connection,
+    rows: Iterable[sqlite3.Row],
+    *,
+    dry_run: bool,
+) -> int:
+    updates: List[Tuple[float, float, int]] = []
+    success_count = 0
+    for row in rows:
+        query = build_query(row)
+        zoo_id = row["zoo_id"]
+        if not query:
+            print(f"[SKIP] Zoo {zoo_id}: missing name/city", file=sys.stderr)
+            continue
+        kwargs = {}
+        bias = make_bias(row)
+        if bias:
+            kwargs["bias_circle"] = bias
+        try:
+            result = lookup_coords(query, **kwargs)
+        except ApiError as exc:
+            print(f"[FAIL] Zoo {zoo_id} ({query}): {exc}", file=sys.stderr)
+            continue
+        lat = result["latitude"]
+        lng = result["longitude"]
+        print(
+            f"[OK] Zoo {zoo_id}: {query} -> lat={lat:.6f}, lng={lng:.6f} "
+            f"(source={result.get('source')})"
+        )
+        success_count += 1
+        if not dry_run:
+            updates.append((lat, lng, zoo_id))
+
+    if updates and not dry_run:
+        with conn:
+            conn.executemany(
+                "UPDATE zoo SET latitude_google=?, longitude_google=? WHERE zoo_id=?",
+                updates,
+            )
+    return success_count
+
+
+def parse_args(argv: Optional[Sequence[str]] = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Fetch Google Maps coordinates for zoos and store them in the database."
+    )
+    parser.add_argument("--db", default=DB_FILE, help="Path to SQLite database (default: %(default)s)")
+    parser.add_argument("--limit", type=int, help="Maximum number of zoos to process")
+    parser.add_argument("--dry-run", action="store_true", help="Fetch coordinates without updating the DB")
+    return parser.parse_args(argv)
+
+
+def main(argv: Optional[Sequence[str]] = None) -> int:
+    args = parse_args(argv)
+    conn = sqlite3.connect(args.db, timeout=30)
+    conn.row_factory = sqlite3.Row
+    try:
+        ensure_google_columns(conn)
+        rows = load_target_rows(conn, args.limit)
+        if not rows:
+            print("No zoos require Google coordinates.")
+            return 0
+        updated = update_google_coordinates(conn, rows, dry_run=args.dry_run)
+        if args.dry_run:
+            print(f"Dry run complete – {updated} updates ready.")
+        else:
+            print(f"Updated {updated} zoos with Google coordinates.")
+        return 0
+    finally:
+        conn.close()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/google_places_lookup.py
+++ b/google_places_lookup.py
@@ -3,22 +3,12 @@
 """
 Google Places lookup: free-text search -> lat/lng
 
-Two modes:
-1) Default (cheaper): Text Search (IDs-only) -> Place Details (location only)
-2) --one-call (simpler, pricier): Text Search Pro returning location directly
-
 Auth:
   Set environment variable GOOGLE_MAPS_API_KEY with a Places API (new) key.
 
 Usage examples:
   # Cheapest two-step with a soft location bias (50 km around point):
   python google_places_lookup.py "Sun City Predator World" --bias-circle -25.73 27.09 50000
-
-  # Restrict search to a rectangle (south, west, north, east):
-  python google_places_lookup.py "Sun City Predator World" --restrict-rect -26.1 26.8 -25.4 27.5
-
-  # One-call mode (Text Search Pro: returns location directly):
-  python google_places_lookup.py "Sun City Predator World" --one-call --bias-circle -25.73 27.09 50000
 
 Outputs a compact JSON object with name, place_id, latitude, longitude.
 """
@@ -28,7 +18,7 @@ import sys
 import json
 import time
 import argparse
-from typing import Dict, Any, Optional, Tuple
+from typing import Dict, Any, Optional
 import requests
 
 TEXT_SEARCH_URL = "https://places.googleapis.com/v1/places:searchText"
@@ -83,7 +73,7 @@ def _retry_get(url: str, headers: Dict[str, str]) -> Dict[str, Any]:
 # ---------- Payload builders ----------
 
 def make_location_bias(args) -> Optional[Dict[str, Any]]:
-    if args.restrict_rect or args.restrict_circle:
+    if args.restrict_circle:
         return None  # mutually exclusive with restriction (we enforce in argparse)
     if args.bias_circle:
         lat, lng, radius = args.bias_circle
@@ -98,10 +88,6 @@ def make_location_restriction(args) -> Optional[Dict[str, Any]]:
     if args.restrict_circle:
         lat, lng, radius = args.restrict_circle
         return {"circle": {"center": {"latitude": lat, "longitude": lng}, "radius": int(radius)}}
-    if args.restrict_rect:
-        s, w, n, e = args.restrict_rect
-        return {"rectangle": {"low": {"latitude": s, "longitude": w},
-                              "high": {"latitude": n, "longitude": e}}}
     return None
 
 # ---------- Core calls ----------
@@ -120,20 +106,6 @@ def text_search_ids_only(api_key: str, query: str, args) -> Dict[str, Any]:
         body["locationRestriction"] = lr
     return _retry_request("POST", TEXT_SEARCH_URL, headers, body)
 
-def text_search_with_location(api_key: str, query: str, args) -> Dict[str, Any]:
-    # One-call mode (Text Search Pro) asks directly for places.location
-    field_mask = "places.id,places.name,places.location"
-    headers = _headers(api_key, field_mask)
-    body: Dict[str, Any] = {"textQuery": query}
-    lb = make_location_bias(args)
-    lr = make_location_restriction(args)
-    if lb and lr:
-        raise ValueError("locationBias and locationRestriction are mutually exclusive.")
-    if lb:
-        body["locationBias"] = lb
-    if lr:
-        body["locationRestriction"] = lr
-    return _retry_request("POST", TEXT_SEARCH_URL, headers, body)
 
 def place_details_location(api_key: str, place_id: str) -> Dict[str, Any]:
     field_mask = "id,location,name"
@@ -143,10 +115,10 @@ def place_details_location(api_key: str, place_id: str) -> Dict[str, Any]:
 
 # ---------- Public API ----------
 
-def lookup_coords(query: str, one_call: bool = False, **kwargs) -> Dict[str, Any]:
+def lookup_coords(query: str, **kwargs) -> Dict[str, Any]:
     """
-    Programmatic API: lookup_coords("query", one_call=False, bias_circle=(-25.73, 27.09, 50000), ...)
-    Returns: {"name": str, "place_id": str, "latitude": float, "longitude": float, "source": "details"|"text_search_pro"}
+    Programmatic API: lookup_coords("query", bias_circle=(-25.73, 27.09, 50000), ...)
+    Returns: {"name": str, "place_id": str, "latitude": float, "longitude": float, "source": "details"}
     """
     class _Args:  # quick shim for builder functions
         def __init__(self, **k): self.__dict__.update(k)
@@ -157,31 +129,12 @@ def lookup_coords(query: str, one_call: bool = False, **kwargs) -> Dict[str, Any
     if not api_key:
         raise ApiError("Missing GOOGLE_MAPS_API_KEY in environment.")
 
-    if one_call:
-        ts = text_search_with_location(api_key, query, args)
-        places = ts.get("places") or []
-        if not places:
-            raise ApiError("No results from Text Search.")
-        p0 = places[0]
-        loc = (p0.get("location") or {}).get("latLng") or {}
-        if "latitude" not in loc or "longitude" not in loc:
-            raise ApiError("Text Search did not return location for the top result.")
-        return {
-            "name": p0.get("name"),
-            "place_id": p0.get("id"),
-            "latitude": loc["latitude"],
-            "longitude": loc["longitude"],
-            "source": "text_search_pro",
-        }
-
     # Two-step: IDs-only -> Details (location)
     ts = text_search_ids_only(api_key, query, args)
     places = ts.get("places") or []
-    print(places)
     if not places:
         raise ApiError("No results from Text Search (IDs only).")
     place_id = places[0].get("id")
-    print(place_id)
     if not place_id:
         raise ApiError("Top result missing place id.")
     det = place_details_location(api_key, place_id)
@@ -212,14 +165,11 @@ def parse_args(argv=None):
     # Restriction (hard)
     p.add_argument("--restrict-circle", nargs=3, type=float, metavar=("LAT", "LNG", "RADIUS_M"),
                    help="Location restriction as circle with radius in meters")
-    p.add_argument("--restrict-rect", nargs=4, type=float, metavar=("S", "W", "N", "E"),
-                   help="Location restriction as rectangle (south, west, north, east)")
-    p.add_argument("--one-call", action="store_true", help="Use Text Search Pro to return location directly (costs more)")
     p.add_argument("--pretty", action="store_true", help="Pretty-print JSON")
     args = p.parse_args(argv)
 
     # Enforce mutual exclusivity: any bias* with any restrict* is not allowed
-    if (args.bias_circle or args.bias_rect) and (args.restrict_circle or args.restrict_rect):
+    if (args.bias_circle or args.bias_rect) and args.restrict_circle:
         p.error("locationBias and locationRestriction are mutually exclusive; choose one.")
     return args
 
@@ -232,11 +182,9 @@ def main(argv=None):
     try:
         result = lookup_coords(
             args.query,
-            one_call=args.one_call,
             bias_circle=tuple(args.bias_circle) if args.bias_circle else None,
             bias_rect=tuple(args.bias_rect) if args.bias_rect else None,
             restrict_circle=tuple(args.restrict_circle) if args.restrict_circle else None,
-            restrict_rect=tuple(args.restrict_rect) if args.restrict_rect else None,
         )
     except Exception as e:
         print(json.dumps({"error": str(e)}), flush=True)


### PR DESCRIPTION
## Summary
- simplify `google_places_lookup` by removing the one-call mode and rectangle restriction options
- add `google_places_fetch_zoo_coords.py` to populate Google-based latitude/longitude columns for zoos in order of species count

## Testing
- ruff check .
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e98ef83c48832883726ece821c806e